### PR TITLE
Replace unavailable WanVideo nodes with compatible workflow

### DIFF
--- a/workflow-full-firm-and-bouncy-breasts-wan22-vafG1WJ7DDiCFAO8IpbY-wwrs-openart.ai (1).json
+++ b/workflow-full-firm-and-bouncy-breasts-wan22-vafG1WJ7DDiCFAO8IpbY-wwrs-openart.ai (1).json
@@ -1,1 +1,896 @@
-{"last_link_id":80,"nodes":[{"outputs":[],"color":"#432","widgets_values":["If you have Triton installed, connect this for ~30% speed increase"],"inputs":[],"flags":{},"type":"Note","mode":0,"bgcolor":"#653","size":[303.0501403808594,88],"pos":[1155.551513671875,1587.7467041015625],"id":1,"properties":{"widget_ue_connectable":{}},"order":0},{"mode":0,"outputs":[{"name":"model","links":[7],"label":"model","type":"WANVIDEOMODEL","localized_name":"model"}],"bgcolor":"#335","size":[201.76815795898438,46],"color":"#223","pos":[2653.844482421875,1698.0625],"inputs":[{"name":"model","link":1,"label":"model","type":"WANVIDEOMODEL","localized_name":"model"},{"shape":7,"name":"block_swap_args","link":2,"label":"block_swap_args","type":"BLOCKSWAPARGS","localized_name":"block_swap_args"}],"flags":{},"id":2,"type":"WanVideoSetBlockSwap","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"7e290c67bff1f906cdab84523018573f6c9d4d7f","widget_ue_connectable":{},"Node name for S&R":"WanVideoSetBlockSwap"},"order":33},{"mode":0,"outputs":[{"name":"model","links":[5],"label":"model","type":"WANVIDEOMODEL","localized_name":"model"}],"bgcolor":"#335","size":[201.76815795898438,46],"color":"#223","pos":[2664.411865234375,2137.128662109375],"inputs":[{"name":"model","link":3,"label":"model","type":"WANVIDEOMODEL","localized_name":"model"},{"shape":7,"name":"block_swap_args","link":4,"label":"block_swap_args","type":"BLOCKSWAPARGS","localized_name":"block_swap_args"}],"flags":{},"id":3,"type":"WanVideoSetBlockSwap","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"7e290c67bff1f906cdab84523018573f6c9d4d7f","widget_ue_connectable":{},"Node name for S&R":"WanVideoSetBlockSwap"},"order":34},{"mode":0,"outputs":[{"name":"model","links":[17],"label":"model","type":"WANVIDEOMODEL","localized_name":"model"}],"bgcolor":"#335","size":[222.27981567382812,46],"color":"#223","pos":[3085.199951171875,2181.210693359375],"inputs":[{"name":"model","link":5,"label":"model","type":"WANVIDEOMODEL","localized_name":"model"},{"shape":7,"name":"lora","link":6,"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"flags":{},"id":4,"type":"WanVideoSetLoRAs","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoSetLoRAs"},"order":40},{"mode":0,"outputs":[{"name":"model","links":[41],"label":"model","type":"WANVIDEOMODEL","localized_name":"model"}],"bgcolor":"#335","size":[222.27981567382812,46],"color":"#223","pos":[3101.433837890625,1939.6783447265625],"inputs":[{"name":"model","link":7,"label":"model","type":"WANVIDEOMODEL","localized_name":"model"},{"shape":7,"name":"lora","link":8,"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"flags":{},"id":5,"type":"WanVideoSetLoRAs","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoSetLoRAs"},"order":41},{"mode":0,"outputs":[{"name":"image","links":[54],"label":"图像","type":"IMAGE","localized_name":"image"},{"name":"624 width","label":"宽度","type":"INT","localized_name":"width"},{"name":"832 height","label":"高度","type":"INT","localized_name":"height"},{"name":"197 count","label":"数量","type":"INT","localized_name":"count"}],"size":[240.41265869140625,86],"pos":[4841.33203125,2147.88818359375],"inputs":[{"name":"image","link":9,"label":"图像","type":"IMAGE","localized_name":"image"}],"flags":{},"id":6,"type":"GetImageSizeAndCount","properties":{"cnr_id":"comfyui-kjnodes","ver":"a6b867b63a29ca48ddb15c589e17a9f2d8530d57","widget_ue_connectable":{},"Node name for S&R":"GetImageSizeAndCount"},"order":55},{"mode":0,"outputs":[{"name":"image","links":[13],"label":"图像","type":"IMAGE","localized_name":"image"},{"name":"mask","label":"遮罩","type":"MASK","localized_name":"mask"},{"name":"original_size","label":"原始大小","type":"BOX","localized_name":"original_size"},{"name":"width","links":[14],"label":"width","type":"INT","localized_name":"width"},{"name":"height","links":[15],"label":"height","type":"INT","localized_name":"height"}],"size":[504,330],"color":"rgba(38, 73, 116, 0.7)","pos":[2868.251953125,1311.2508544921875],"widgets_values":["original",1,1,"crop","lanczos","16","longest",720,"#000000"],"inputs":[{"shape":7,"name":"image","link":80,"label":"图像","type":"IMAGE","localized_name":"image"},{"shape":7,"name":"mask","label":"遮罩","type":"MASK","localized_name":"mask"},{"widget":{"name":"aspect_ratio"},"name":"aspect_ratio","label":"aspect_ratio","type":"COMBO","localized_name":"宽高比"},{"widget":{"name":"proportional_width"},"name":"proportional_width","label":"proportional_width","type":"INT","localized_name":"比例宽"},{"widget":{"name":"proportional_height"},"name":"proportional_height","label":"proportional_height","type":"INT","localized_name":"比例高"},{"widget":{"name":"fit"},"name":"fit","label":"fit","type":"COMBO","localized_name":"缩放模式"},{"widget":{"name":"method"},"name":"method","label":"method","type":"COMBO","localized_name":"采样方法"},{"widget":{"name":"round_to_multiple"},"name":"round_to_multiple","label":"round_to_multiple","type":"COMBO","localized_name":"倍数取整"},{"widget":{"name":"scale_to_side"},"name":"scale_to_side","label":"scale_to_side","type":"COMBO","localized_name":"缩放到边"},{"widget":{"name":"scale_to_length"},"name":"scale_to_length","link":11,"label":"scale_to_length","type":"INT","localized_name":"缩放到长度"},{"widget":{"name":"background_color"},"name":"background_color","label":"background_color","type":"STRING","localized_name":"background_color"}],"flags":{},"id":7,"type":"LayerUtility: ImageScaleByAspectRatio V2","properties":{"widget_ue_connectable":{},"Node name for S&R":"LayerUtility: ImageScaleByAspectRatio V2"},"order":50},{"outputs":[{"name":"vae","slot_index":0,"links":[12,55],"label":"vae","type":"WANVAE","localized_name":"vae"}],"color":"#322","widgets_values":["Wan2_1_VAE_bf16.safetensors","bf16"],"inputs":[{"shape":7,"name":"compile_args","label":"compile_args","type":"WANCOMPILEARGS","localized_name":"compile_args"},{"widget":{"name":"model_name"},"name":"model_name","label":"model_name","type":"COMBO","localized_name":"model_name"},{"widget":{"name":"precision"},"shape":7,"name":"precision","label":"precision","type":"COMBO","localized_name":"precision"}],"flags":{},"type":"WanVideoVAELoader","mode":0,"bgcolor":"#533","size":[315,82],"pos":[3489.524658203125,1406.227783203125],"id":8,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoVAELoader"},"order":1},{"outputs":[{"name":"image_embeds","links":[19,43],"label":"image_embeds","type":"WANVIDIMAGE_EMBEDS","localized_name":"image_embeds"}],"color":"#322","widgets_values":[832,480,81,0,1,1,true,false,false],"inputs":[{"shape":7,"name":"vae","link":12,"label":"vae","type":"WANVAE","localized_name":"vae"},{"shape":7,"name":"clip_embeds","label":"clip_embeds","type":"WANVIDIMAGE_CLIPEMBEDS","localized_name":"clip_embeds"},{"shape":7,"name":"start_image","link":13,"label":"start_image","type":"IMAGE","localized_name":"start_image"},{"shape":7,"name":"end_image","label":"end_image","type":"IMAGE","localized_name":"end_image"},{"shape":7,"name":"control_embeds","label":"control_embeds","type":"WANVIDIMAGE_EMBEDS","localized_name":"control_embeds"},{"shape":7,"name":"temporal_mask","label":"temporal_mask","type":"MASK","localized_name":"temporal_mask"},{"shape":7,"name":"extra_latents","label":"extra_latents","type":"LATENT","localized_name":"extra_latents"},{"shape":7,"name":"add_cond_latents","label":"add_cond_latents","type":"ADD_COND_LATENTS","localized_name":"add_cond_latents"},{"widget":{"name":"width"},"name":"width","link":14,"label":"width","type":"INT","localized_name":"width"},{"widget":{"name":"height"},"name":"height","link":15,"label":"height","type":"INT","localized_name":"height"},{"widget":{"name":"num_frames"},"name":"num_frames","link":16,"label":"num_frames","type":"INT","localized_name":"num_frames"},{"widget":{"name":"noise_aug_strength"},"name":"noise_aug_strength","label":"noise_aug_strength","type":"FLOAT","localized_name":"noise_aug_strength"},{"widget":{"name":"start_latent_strength"},"name":"start_latent_strength","label":"start_latent_strength","type":"FLOAT","localized_name":"start_latent_strength"},{"widget":{"name":"end_latent_strength"},"name":"end_latent_strength","label":"end_latent_strength","type":"FLOAT","localized_name":"end_latent_strength"},{"widget":{"name":"force_offload"},"name":"force_offload","label":"force_offload","type":"BOOLEAN","localized_name":"force_offload"},{"widget":{"name":"fun_or_fl2v_model"},"shape":7,"name":"fun_or_fl2v_model","label":"fun_or_fl2v_model","type":"BOOLEAN","localized_name":"fun_or_fl2v_model"},{"widget":{"name":"tiled_vae"},"shape":7,"name":"tiled_vae","label":"tiled_vae","type":"BOOLEAN","localized_name":"tiled_vae"}],"flags":{},"type":"WanVideoImageToVideoEncode","mode":0,"bgcolor":"#533","size":[308.2320251464844,390],"pos":[3516.671630859375,1699.0167236328125],"id":9,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"7e290c67bff1f906cdab84523018573f6c9d4d7f","widget_ue_connectable":{"width":true,"height":true},"Node name for S&R":"WanVideoImageToVideoEncode"},"order":51},{"outputs":[{"name":"wan_t5_model","slot_index":0,"links":[30],"label":"wan_t5_model","type":"WANTEXTENCODER","localized_name":"wan_t5_model"}],"color":"#332922","widgets_values":["umt5-xxl-enc-bf16.safetensors","bf16","offload_device","disabled"],"inputs":[{"widget":{"name":"model_name"},"name":"model_name","label":"model_name","type":"COMBO","localized_name":"model_name"},{"widget":{"name":"precision"},"name":"precision","label":"precision","type":"COMBO","localized_name":"precision"},{"widget":{"name":"load_device"},"shape":7,"name":"load_device","label":"load_device","type":"COMBO","localized_name":"load_device"},{"widget":{"name":"quantization"},"shape":7,"name":"quantization","label":"quantization","type":"COMBO","localized_name":"quantization"}],"flags":{},"type":"LoadWanVideoT5TextEncoder","mode":0,"bgcolor":"#593930","size":[377.1661376953125,130],"pos":[2278.572509765625,2371.281982421875],"id":10,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"LoadWanVideoT5TextEncoder"},"order":2},{"mode":0,"outputs":[{"name":"samples","slot_index":0,"links":[56],"label":"samples","type":"LATENT","localized_name":"samples"},{"name":"denoised_samples","label":"denoised_samples","type":"LATENT","localized_name":"denoised_samples"}],"size":[315,975],"pos":[4321.5986328125,2004.7274169921875],"widgets_values":[6,1,8,317786370021218,"fixed",true,"unipc",0,1,false,"comfy",10,-1,false],"inputs":[{"name":"model","link":17,"label":"model","type":"WANVIDEOMODEL","localized_name":"model"},{"name":"text_embeds","link":18,"label":"text_embeds","type":"WANVIDEOTEXTEMBEDS","localized_name":"text_embeds"},{"name":"image_embeds","link":19,"label":"image_embeds","type":"WANVIDIMAGE_EMBEDS","localized_name":"image_embeds"},{"shape":7,"name":"samples","link":20,"label":"samples","type":"LATENT","localized_name":"samples"},{"shape":7,"name":"feta_args","label":"feta_args","type":"FETAARGS","localized_name":"feta_args"},{"shape":7,"name":"context_options","label":"context_options","type":"WANVIDCONTEXT","localized_name":"context_options"},{"shape":7,"name":"cache_args","label":"cache_args","type":"CACHEARGS","localized_name":"cache_args"},{"shape":7,"name":"flowedit_args","label":"flowedit_args","type":"FLOWEDITARGS","localized_name":"flowedit_args"},{"shape":7,"name":"slg_args","label":"slg_args","type":"SLGARGS","localized_name":"slg_args"},{"shape":7,"name":"loop_args","label":"loop_args","type":"LOOPARGS","localized_name":"loop_args"},{"shape":7,"name":"experimental_args","label":"experimental_args","type":"EXPERIMENTALARGS","localized_name":"experimental_args"},{"shape":7,"name":"sigmas","label":"sigmas","type":"SIGMAS","localized_name":"sigmas"},{"shape":7,"name":"unianimate_poses","label":"unianimate_poses","type":"UNIANIMATE_POSE","localized_name":"unianimate_poses"},{"shape":7,"name":"fantasytalking_embeds","label":"fantasytalking_embeds","type":"FANTASYTALKING_EMBEDS","localized_name":"fantasytalking_embeds"},{"shape":7,"name":"uni3c_embeds","label":"uni3c_embeds","type":"UNI3C_EMBEDS","localized_name":"uni3c_embeds"},{"shape":7,"name":"multitalk_embeds","label":"multitalk_embeds","type":"MULTITALK_EMBEDS","localized_name":"multitalk_embeds"},{"shape":7,"name":"freeinit_args","label":"freeinit_args","type":"FREEINITARGS","localized_name":"freeinit_args"},{"widget":{"name":"steps"},"name":"steps","link":21,"label":"steps","type":"INT","localized_name":"steps"},{"widget":{"name":"cfg"},"name":"cfg","label":"cfg","type":"FLOAT","localized_name":"cfg"},{"widget":{"name":"shift"},"name":"shift","link":22,"label":"shift","type":"FLOAT","localized_name":"shift"},{"widget":{"name":"seed"},"name":"seed","link":23,"label":"seed","type":"INT","localized_name":"seed"},{"widget":{"name":"force_offload"},"name":"force_offload","label":"force_offload","type":"BOOLEAN","localized_name":"force_offload"},{"widget":{"name":"scheduler"},"name":"scheduler","link":24,"label":"scheduler","type":"COMBO","localized_name":"scheduler"},{"widget":{"name":"riflex_freq_index"},"name":"riflex_freq_index","label":"riflex_freq_index","type":"INT","localized_name":"riflex_freq_index"},{"widget":{"name":"denoise_strength"},"shape":7,"name":"denoise_strength","label":"denoise_strength","type":"FLOAT","localized_name":"denoise_strength"},{"widget":{"name":"batched_cfg"},"shape":7,"name":"batched_cfg","label":"batched_cfg","type":"BOOLEAN","localized_name":"batched_cfg"},{"widget":{"name":"rope_function"},"shape":7,"name":"rope_function","label":"rope_function","type":"COMBO","localized_name":"rope_function"},{"widget":{"name":"start_step"},"shape":7,"name":"start_step","link":25,"label":"start_step","type":"INT","localized_name":"start_step"},{"widget":{"name":"end_step"},"shape":7,"name":"end_step","link":26,"label":"end_step","type":"INT","localized_name":"end_step"},{"widget":{"name":"add_noise_to_samples"},"shape":7,"name":"add_noise_to_samples","label":"add_noise_to_samples","type":"BOOLEAN","localized_name":"add_noise_to_samples"}],"flags":{},"id":11,"type":"WanVideoSampler","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{"start_step":true,"seed":true,"steps":true},"Node name for S&R":"WanVideoSampler"},"order":53},{"outputs":[],"color":"#432","widgets_values":["最长边"],"inputs":[],"flags":{},"type":"Note","mode":0,"bgcolor":"#653","size":[210,88],"pos":[1971.8499755859375,1125.137451171875],"id":12,"properties":{"widget_ue_connectable":{}},"order":3},{"outputs":[{"name":"model","slot_index":0,"links":[1],"label":"model","type":"WANVIDEOMODEL","localized_name":"model"}],"color":"#223","widgets_values":["Wan2_2-I2V-A14B-HIGH_fp8_e4m3fn_scaled_KJ.safetensors","bf16","fp8_e4m3fn_scaled","offload_device","sageattn"],"inputs":[{"shape":7,"name":"compile_args","link":27,"label":"compile_args","type":"WANCOMPILEARGS","localized_name":"compile_args"},{"shape":7,"name":"block_swap_args","label":"block_swap_args","type":"BLOCKSWAPARGS","localized_name":"block_swap_args"},{"shape":7,"name":"lora","label":"lora","type":"WANVIDLORA","localized_name":"lora"},{"shape":7,"name":"vram_management_args","label":"vram_management_args","type":"VRAM_MANAGEMENTARGS","localized_name":"vram_management_args"},{"shape":7,"name":"extra_model","label":"extra_model","type":"VACEPATH","localized_name":"extra_model"},{"shape":7,"name":"fantasytalking_model","label":"fantasytalking_model","type":"FANTASYTALKINGMODEL","localized_name":"fantasytalking_model"},{"shape":7,"name":"multitalk_model","label":"multitalk_model","type":"MULTITALKMODEL","localized_name":"multitalk_model"},{"shape":7,"name":"fantasyportrait_model","label":"fantasyportrait_model","type":"FANTASYPORTRAITMODEL","localized_name":"fantasyportrait_model"},{"widget":{"name":"model"},"name":"model","label":"model","type":"COMBO","localized_name":"model"},{"widget":{"name":"base_precision"},"name":"base_precision","label":"base_precision","type":"COMBO","localized_name":"base_precision"},{"widget":{"name":"quantization"},"name":"quantization","label":"quantization","type":"COMBO","localized_name":"quantization"},{"widget":{"name":"load_device"},"name":"load_device","label":"load_device","type":"COMBO","localized_name":"load_device"},{"widget":{"name":"attention_mode"},"shape":7,"name":"attention_mode","label":"attention_mode","type":"COMBO","localized_name":"attention_mode"},{"shape":7,"name":"vace_model","label":"vace_model","type":"VACEPATH","localized_name":"vace_model"}],"flags":{},"type":"WanVideoModelLoader","mode":0,"bgcolor":"#335","size":[477.4410095214844,314],"pos":[2105.55126953125,1657.7467041015625],"id":13,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoModelLoader"},"order":22},{"outputs":[{"name":"model","slot_index":0,"links":[3],"label":"model","type":"WANVIDEOMODEL","localized_name":"model"}],"color":"#223","widgets_values":["Wan2_2-I2V-A14B-LOW_fp8_e4m3fn_scaled_KJ.safetensors","bf16","fp8_e4m3fn_scaled","offload_device","sageattn"],"inputs":[{"shape":7,"name":"compile_args","link":28,"label":"compile_args","type":"WANCOMPILEARGS","localized_name":"compile_args"},{"shape":7,"name":"block_swap_args","label":"block_swap_args","type":"BLOCKSWAPARGS","localized_name":"block_swap_args"},{"shape":7,"name":"lora","label":"lora","type":"WANVIDLORA","localized_name":"lora"},{"shape":7,"name":"vram_management_args","label":"vram_management_args","type":"VRAM_MANAGEMENTARGS","localized_name":"vram_management_args"},{"shape":7,"name":"extra_model","label":"extra_model","type":"VACEPATH","localized_name":"extra_model"},{"shape":7,"name":"fantasytalking_model","label":"fantasytalking_model","type":"FANTASYTALKINGMODEL","localized_name":"fantasytalking_model"},{"shape":7,"name":"multitalk_model","label":"multitalk_model","type":"MULTITALKMODEL","localized_name":"multitalk_model"},{"shape":7,"name":"fantasyportrait_model","label":"fantasyportrait_model","type":"FANTASYPORTRAITMODEL","localized_name":"fantasyportrait_model"},{"widget":{"name":"model"},"name":"model","label":"model","type":"COMBO","localized_name":"model"},{"widget":{"name":"base_precision"},"name":"base_precision","label":"base_precision","type":"COMBO","localized_name":"base_precision"},{"widget":{"name":"quantization"},"name":"quantization","label":"quantization","type":"COMBO","localized_name":"quantization"},{"widget":{"name":"load_device"},"name":"load_device","label":"load_device","type":"COMBO","localized_name":"load_device"},{"widget":{"name":"attention_mode"},"shape":7,"name":"attention_mode","label":"attention_mode","type":"COMBO","localized_name":"attention_mode"},{"shape":7,"name":"vace_model","label":"vace_model","type":"VACEPATH","localized_name":"vace_model"}],"flags":{},"type":"WanVideoModelLoader","mode":0,"bgcolor":"#335","size":[477.4410095214844,314],"pos":[2105.55126953125,2017.7467041015625],"id":14,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoModelLoader"},"order":23},{"outputs":[{"name":"lora","links":[6],"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"color":"#223","widgets_values":["Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors",1,true,false],"inputs":[{"shape":7,"name":"prev_lora","link":29,"label":"prev_lora","type":"WANVIDLORA","localized_name":"prev_lora"},{"shape":7,"name":"blocks","label":"blocks","type":"SELECTEDBLOCKS","localized_name":"blocks"},{"widget":{"name":"lora"},"name":"lora","label":"lora","type":"COMBO","localized_name":"lora"},{"widget":{"name":"strength"},"name":"strength","label":"strength","type":"FLOAT","localized_name":"strength"},{"widget":{"name":"low_mem_load"},"shape":7,"name":"low_mem_load","label":"low_mem_load","type":"BOOLEAN","localized_name":"low_mem_load"},{"widget":{"name":"merge_loras"},"shape":7,"name":"merge_loras","label":"merge_loras","type":"BOOLEAN","localized_name":"merge_loras"}],"flags":{},"type":"WanVideoLoraSelect","mode":0,"bgcolor":"#335","size":[624.4888305664062,150],"pos":[1380.906005859375,2144.21435546875],"id":15,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoLoraSelect"},"order":35},{"outputs":[{"name":"text_embeds","slot_index":0,"links":[18,42],"label":"text_embeds","type":"WANVIDEOTEXTEMBEDS","localized_name":"text_embeds"}],"color":"#332922","widgets_values":["女人拿着相机拍照","色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走",true,false,"gpu"],"inputs":[{"shape":7,"name":"t5","link":30,"label":"t5","type":"WANTEXTENCODER","localized_name":"t5"},{"shape":7,"name":"model_to_offload","label":"model_to_offload","type":"WANVIDEOMODEL","localized_name":"model_to_offload"},{"widget":{"name":"positive_prompt"},"name":"positive_prompt","link":31,"label":"positive_prompt","type":"STRING","localized_name":"positive_prompt"},{"widget":{"name":"negative_prompt"},"name":"negative_prompt","label":"negative_prompt","type":"STRING","localized_name":"negative_prompt"},{"widget":{"name":"force_offload"},"shape":7,"name":"force_offload","label":"force_offload","type":"BOOLEAN","localized_name":"force_offload"},{"widget":{"name":"use_disk_cache"},"shape":7,"name":"use_disk_cache","label":"use_disk_cache","type":"BOOLEAN","localized_name":"use_disk_cache"},{"widget":{"name":"device"},"shape":7,"name":"device","label":"device","type":"COMBO","localized_name":"device"}],"flags":{},"type":"WanVideoTextEncode","mode":0,"bgcolor":"#593930","size":[474.3573303222656,316.48370361328125],"pos":[2791.436767578125,2361.714599609375],"id":16,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{"positive_prompt":true},"Node name for S&R":"WanVideoTextEncode"},"order":26},{"outputs":[{"name":"block_swap_args","slot_index":0,"links":[2,4],"label":"block_swap_args","type":"BLOCKSWAPARGS","localized_name":"block_swap_args"}],"color":"#223","widgets_values":[40,false,false,false,1,0,false],"inputs":[{"widget":{"name":"blocks_to_swap"},"name":"blocks_to_swap","label":"blocks_to_swap","type":"INT","localized_name":"blocks_to_swap"},{"widget":{"name":"offload_img_emb"},"name":"offload_img_emb","label":"offload_img_emb","type":"BOOLEAN","localized_name":"offload_img_emb"},{"widget":{"name":"offload_txt_emb"},"name":"offload_txt_emb","label":"offload_txt_emb","type":"BOOLEAN","localized_name":"offload_txt_emb"},{"widget":{"name":"use_non_blocking"},"shape":7,"name":"use_non_blocking","label":"use_non_blocking","type":"BOOLEAN","localized_name":"use_non_blocking"},{"widget":{"name":"vace_blocks_to_swap"},"shape":7,"name":"vace_blocks_to_swap","label":"vace_blocks_to_swap","type":"INT","localized_name":"vace_blocks_to_swap"},{"widget":{"name":"prefetch_blocks"},"shape":7,"name":"prefetch_blocks","label":"prefetch_blocks","type":"INT","localized_name":"prefetch_blocks"},{"widget":{"name":"block_swap_debug"},"shape":7,"name":"block_swap_debug","label":"block_swap_debug","type":"BOOLEAN","localized_name":"block_swap_debug"}],"flags":{},"type":"WanVideoBlockSwap","mode":0,"bgcolor":"#335","size":[315,202],"pos":[2632.41650390625,1871.1734619140625],"id":17,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoBlockSwap"},"order":4},{"mode":4,"outputs":[{"name":"torch_compile_args","slot_index":0,"links":[27,28],"label":"torch_compile_args","type":"WANCOMPILEARGS","localized_name":"torch_compile_args"}],"size":[390.5999755859375,202],"pos":[1496.098876953125,1500.603515625],"widgets_values":["inductor",false,"default",false,64,true,128],"inputs":[{"widget":{"name":"backend"},"name":"backend","label":"backend","type":"COMBO","localized_name":"backend"},{"widget":{"name":"fullgraph"},"name":"fullgraph","label":"fullgraph","type":"BOOLEAN","localized_name":"fullgraph"},{"widget":{"name":"mode"},"name":"mode","label":"mode","type":"COMBO","localized_name":"mode"},{"widget":{"name":"dynamic"},"name":"dynamic","label":"dynamic","type":"BOOLEAN","localized_name":"dynamic"},{"widget":{"name":"dynamo_cache_size_limit"},"name":"dynamo_cache_size_limit","label":"dynamo_cache_size_limit","type":"INT","localized_name":"dynamo_cache_size_limit"},{"widget":{"name":"compile_transformer_blocks_only"},"name":"compile_transformer_blocks_only","label":"compile_transformer_blocks_only","type":"BOOLEAN","localized_name":"compile_transformer_blocks_only"},{"widget":{"name":"dynamo_recompile_limit"},"shape":7,"name":"dynamo_recompile_limit","label":"dynamo_recompile_limit","type":"INT","localized_name":"dynamo_recompile_limit"}],"flags":{},"id":18,"type":"WanVideoTorchCompileSettings","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoTorchCompileSettings"},"order":5},{"outputs":[{"name":"value","links":[34,37,53],"label":"值","type":"INT","localized_name":"value"}],"color":"#1b4669","widgets_values":[8],"inputs":[{"widget":{"name":"value"},"name":"value","label":"value","type":"INT","localized_name":"值"}],"flags":{},"type":"INTConstant","mode":0,"bgcolor":"#29699c","size":[210,58],"pos":[3233.704345703125,2740.372314453125],"id":19,"properties":{"cnr_id":"comfyui-kjnodes","ver":"a6b867b63a29ca48ddb15c589e17a9f2d8530d57","widget_ue_connectable":{},"Node name for S&R":"INTConstant"},"order":6},{"outputs":[{"name":"lora","links":[8],"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"color":"#223","widgets_values":["Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors",3,true,false],"inputs":[{"shape":7,"name":"prev_lora","link":32,"label":"prev_lora","type":"WANVIDLORA","localized_name":"prev_lora"},{"shape":7,"name":"blocks","label":"blocks","type":"SELECTEDBLOCKS","localized_name":"blocks"},{"widget":{"name":"lora"},"name":"lora","label":"lora","type":"COMBO","localized_name":"lora"},{"widget":{"name":"strength"},"name":"strength","link":33,"label":"strength","type":"FLOAT","localized_name":"strength"},{"widget":{"name":"low_mem_load"},"shape":7,"name":"low_mem_load","label":"low_mem_load","type":"BOOLEAN","localized_name":"low_mem_load"},{"widget":{"name":"merge_loras"},"shape":7,"name":"merge_loras","label":"merge_loras","type":"BOOLEAN","localized_name":"merge_loras"}],"flags":{},"type":"WanVideoLoraSelect","mode":0,"bgcolor":"#335","size":[659.4812622070312,150],"pos":[1353.93994140625,1927.1583251953125],"id":20,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoLoraSelect"},"order":36},{"mode":0,"outputs":[{"name":"sigmas","links":[],"label":"sigmas","type":"SIGMAS","localized_name":"sigmas"},{"name":"steps","links":[21],"label":"steps","type":"INT","localized_name":"steps"},{"name":"shift","links":[22],"label":"shift","type":"FLOAT","localized_name":"shift"},{"name":"scheduler","links":[24],"label":"scheduler","type":"COMBO","localized_name":"scheduler"},{"name":"start_step","links":[25],"label":"start_step","type":"INT","localized_name":"start_step"},{"name":"end_step","links":[26],"label":"end_step","type":"INT","localized_name":"end_step"}],"size":[270,254],"pos":[3898.285888671875,3081.662353515625],"widgets_values":["unipc",8,5,0,-1],"inputs":[{"shape":7,"name":"sigmas","label":"sigmas","type":"SIGMAS","localized_name":"sigmas"},{"widget":{"name":"scheduler"},"name":"scheduler","label":"scheduler","type":"COMBO","localized_name":"scheduler"},{"widget":{"name":"steps"},"name":"steps","link":34,"label":"steps","type":"INT","localized_name":"steps"},{"widget":{"name":"shift"},"name":"shift","link":35,"label":"shift","type":"FLOAT","localized_name":"shift"},{"widget":{"name":"start_step"},"name":"start_step","link":36,"label":"start_step","type":"INT","localized_name":"start_step"},{"widget":{"name":"end_step"},"name":"end_step","label":"end_step","type":"INT","localized_name":"end_step"}],"flags":{},"id":21,"type":"WanVideoScheduler","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoScheduler"},"order":28},{"mode":0,"outputs":[{"name":"sigmas","links":[],"label":"sigmas","type":"SIGMAS","localized_name":"sigmas"},{"name":"steps","links":[45],"label":"steps","type":"INT","localized_name":"steps"},{"name":"shift","links":[47],"label":"shift","type":"FLOAT","localized_name":"shift"},{"name":"scheduler","links":[49],"label":"scheduler","type":"COMBO","localized_name":"scheduler"},{"name":"start_step","links":[50],"label":"start_step","type":"INT","localized_name":"start_step"},{"name":"end_step","links":[51],"label":"end_step","type":"INT","localized_name":"end_step"}],"size":[270,254],"pos":[3593.184326171875,2780.482177734375],"widgets_values":["unipc",8,5,0,-1],"inputs":[{"shape":7,"name":"sigmas","label":"sigmas","type":"SIGMAS","localized_name":"sigmas"},{"widget":{"name":"scheduler"},"name":"scheduler","label":"scheduler","type":"COMBO","localized_name":"scheduler"},{"widget":{"name":"steps"},"name":"steps","link":37,"label":"steps","type":"INT","localized_name":"steps"},{"widget":{"name":"shift"},"name":"shift","link":38,"label":"shift","type":"FLOAT","localized_name":"shift"},{"widget":{"name":"start_step"},"name":"start_step","label":"start_step","type":"INT","localized_name":"start_step"},{"widget":{"name":"end_step"},"name":"end_step","link":39,"label":"end_step","type":"INT","localized_name":"end_step"}],"flags":{},"id":22,"type":"WanVideoScheduler","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoScheduler"},"order":29},{"mode":0,"outputs":[{"name":"step","links":[36,39],"label":"step","type":"INT","localized_name":"step"}],"size":[270,58],"pos":[3287.98583984375,2993.381591796875],"widgets_values":[0.9000000000000002],"inputs":[{"widget":{"name":"sigma"},"name":"sigma","label":"sigma","type":"FLOAT","localized_name":"sigma"}],"flags":{},"id":23,"type":"WanVideoSigmaToStep","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoSigmaToStep"},"order":7},{"outputs":[],"color":"#432","widgets_values":["总帧数"],"inputs":[],"flags":{},"type":"Note","mode":0,"bgcolor":"#653","size":[210,88],"pos":[708.47900390625,2543.170166015625],"id":24,"properties":{"widget_ue_connectable":{}},"order":8},{"mode":0,"outputs":[{"name":"lora","links":[29],"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"size":[247.19297790527344,204.94419860839844],"pos":[955.9537963867188,2245.047119140625],"widgets_values":["Wan2.2-Fun-A14B-InP-low-noise-HPS2.1.safetensors",1,false,false],"inputs":[{"shape":7,"name":"prev_lora","link":40,"label":"prev_lora","type":"WANVIDLORA","localized_name":"prev_lora"},{"shape":7,"name":"blocks","label":"blocks","type":"SELECTEDBLOCKS","localized_name":"blocks"},{"widget":{"name":"lora"},"name":"lora","label":"lora","type":"COMBO","localized_name":"lora"},{"widget":{"name":"strength"},"name":"strength","label":"strength","type":"FLOAT","localized_name":"strength"},{"widget":{"name":"low_mem_load"},"shape":7,"name":"low_mem_load","label":"low_mem_load","type":"BOOLEAN","localized_name":"low_mem_load"},{"widget":{"name":"merge_loras"},"shape":7,"name":"merge_loras","label":"merge_loras","type":"BOOLEAN","localized_name":"merge_loras"}],"flags":{},"id":25,"type":"WanVideoLoraSelect","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoLoraSelect"},"order":25},{"mode":0,"outputs":[{"name":"lora","links":[40],"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"size":[247.19297790527344,204.94419860839844],"pos":[489.19305419921875,2222.603515625],"widgets_values":["bounce_test_LowNoise-000005.safetensors",1,false,false],"inputs":[{"shape":7,"name":"prev_lora","label":"prev_lora","type":"WANVIDLORA","localized_name":"prev_lora"},{"shape":7,"name":"blocks","label":"blocks","type":"SELECTEDBLOCKS","localized_name":"blocks"},{"widget":{"name":"lora"},"name":"lora","label":"lora","type":"COMBO","localized_name":"lora"},{"widget":{"name":"strength"},"name":"strength","label":"strength","type":"FLOAT","localized_name":"strength"},{"widget":{"name":"low_mem_load"},"shape":7,"name":"low_mem_load","label":"low_mem_load","type":"BOOLEAN","localized_name":"low_mem_load"},{"widget":{"name":"merge_loras"},"shape":7,"name":"merge_loras","label":"merge_loras","type":"BOOLEAN","localized_name":"merge_loras"}],"flags":{},"id":26,"type":"WanVideoLoraSelect","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoLoraSelect"},"order":9},{"mode":0,"outputs":[{"name":"prompt","links":[31],"label":"提示词文本","type":"STRING","localized_name":"prompt"},{"name":"show_help","label":"show_help","type":"STRING","localized_name":"show_help"}],"size":[400,200],"pos":[1693.9161376953125,2547.255126953125],"widgets_values":["her breasts bounce, shake, jiggle and sway"],"inputs":[{"widget":{"name":"prompt"},"name":"prompt","label":"prompt","type":"STRING","localized_name":"提示词"}],"flags":{},"id":27,"type":"CR Prompt Text","properties":{"widget_ue_connectable":{},"Node name for S&R":"CR Prompt Text"},"order":10},{"mode":0,"outputs":[{"name":"samples","slot_index":0,"links":[20],"label":"samples","type":"LATENT","localized_name":"samples"},{"name":"denoised_samples","label":"denoised_samples","type":"LATENT","localized_name":"denoised_samples"}],"size":[315,975],"pos":[3948.747314453125,2002.8123779296875],"widgets_values":[6,1,8,317786370021218,"fixed",true,"unipc",0,1,false,"comfy",0,10,false],"inputs":[{"name":"model","link":41,"label":"model","type":"WANVIDEOMODEL","localized_name":"model"},{"name":"text_embeds","link":42,"label":"text_embeds","type":"WANVIDEOTEXTEMBEDS","localized_name":"text_embeds"},{"name":"image_embeds","link":43,"label":"image_embeds","type":"WANVIDIMAGE_EMBEDS","localized_name":"image_embeds"},{"shape":7,"name":"samples","label":"samples","type":"LATENT","localized_name":"samples"},{"shape":7,"name":"feta_args","label":"feta_args","type":"FETAARGS","localized_name":"feta_args"},{"shape":7,"name":"context_options","link":44,"label":"context_options","type":"WANVIDCONTEXT","localized_name":"context_options"},{"shape":7,"name":"cache_args","label":"cache_args","type":"CACHEARGS","localized_name":"cache_args"},{"shape":7,"name":"flowedit_args","label":"flowedit_args","type":"FLOWEDITARGS","localized_name":"flowedit_args"},{"shape":7,"name":"slg_args","label":"slg_args","type":"SLGARGS","localized_name":"slg_args"},{"shape":7,"name":"loop_args","label":"loop_args","type":"LOOPARGS","localized_name":"loop_args"},{"shape":7,"name":"experimental_args","label":"experimental_args","type":"EXPERIMENTALARGS","localized_name":"experimental_args"},{"shape":7,"name":"sigmas","label":"sigmas","type":"SIGMAS","localized_name":"sigmas"},{"shape":7,"name":"unianimate_poses","label":"unianimate_poses","type":"UNIANIMATE_POSE","localized_name":"unianimate_poses"},{"shape":7,"name":"fantasytalking_embeds","label":"fantasytalking_embeds","type":"FANTASYTALKING_EMBEDS","localized_name":"fantasytalking_embeds"},{"shape":7,"name":"uni3c_embeds","label":"uni3c_embeds","type":"UNI3C_EMBEDS","localized_name":"uni3c_embeds"},{"shape":7,"name":"multitalk_embeds","label":"multitalk_embeds","type":"MULTITALK_EMBEDS","localized_name":"multitalk_embeds"},{"shape":7,"name":"freeinit_args","label":"freeinit_args","type":"FREEINITARGS","localized_name":"freeinit_args"},{"widget":{"name":"steps"},"name":"steps","link":45,"label":"steps","type":"INT","localized_name":"steps"},{"widget":{"name":"cfg"},"name":"cfg","link":46,"label":"cfg","type":"FLOAT","localized_name":"cfg"},{"widget":{"name":"shift"},"name":"shift","link":47,"label":"shift","type":"FLOAT","localized_name":"shift"},{"widget":{"name":"seed"},"name":"seed","link":48,"label":"seed","type":"INT","localized_name":"seed"},{"widget":{"name":"force_offload"},"name":"force_offload","label":"force_offload","type":"BOOLEAN","localized_name":"force_offload"},{"widget":{"name":"scheduler"},"name":"scheduler","link":49,"label":"scheduler","type":"COMBO","localized_name":"scheduler"},{"widget":{"name":"riflex_freq_index"},"name":"riflex_freq_index","label":"riflex_freq_index","type":"INT","localized_name":"riflex_freq_index"},{"widget":{"name":"denoise_strength"},"shape":7,"name":"denoise_strength","label":"denoise_strength","type":"FLOAT","localized_name":"denoise_strength"},{"widget":{"name":"batched_cfg"},"shape":7,"name":"batched_cfg","label":"batched_cfg","type":"BOOLEAN","localized_name":"batched_cfg"},{"widget":{"name":"rope_function"},"shape":7,"name":"rope_function","label":"rope_function","type":"COMBO","localized_name":"rope_function"},{"widget":{"name":"start_step"},"shape":7,"name":"start_step","link":50,"label":"start_step","type":"INT","localized_name":"start_step"},{"widget":{"name":"end_step"},"shape":7,"name":"end_step","link":51,"label":"end_step","type":"INT","localized_name":"end_step"},{"widget":{"name":"add_noise_to_samples"},"shape":7,"name":"add_noise_to_samples","label":"add_noise_to_samples","type":"BOOLEAN","localized_name":"add_noise_to_samples"}],"flags":{},"id":28,"type":"WanVideoSampler","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{"seed":true,"cfg":true,"end_step":true,"steps":true},"Node name for S&R":"WanVideoSampler"},"order":52},{"mode":0,"outputs":[{"name":"INT","links":[11],"label":"INT","type":"INT","localized_name":"整数"}],"size":[315,58],"pos":[1866.0872802734375,1279.069091796875],"widgets_values":[832],"inputs":[{"widget":{"name":"value"},"name":"value","label":"value","type":"INT","localized_name":"value"}],"flags":{},"id":31,"type":"JWInteger","properties":{"widget_ue_connectable":{},"Node name for S&R":"JWInteger"},"order":11},{"mode":0,"outputs":[{"name":"lora","links":[52],"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"size":[247.19297790527344,204.94419860839844],"pos":[483.05511474609375,1887.4693603515625],"widgets_values":["bounce_test_HighNoise-000005.safetensors",1.2000000000000002,false,false],"inputs":[{"shape":7,"name":"prev_lora","label":"prev_lora","type":"WANVIDLORA","localized_name":"prev_lora"},{"shape":7,"name":"blocks","label":"blocks","type":"SELECTEDBLOCKS","localized_name":"blocks"},{"widget":{"name":"lora"},"name":"lora","label":"lora","type":"COMBO","localized_name":"lora"},{"widget":{"name":"strength"},"name":"strength","label":"strength","type":"FLOAT","localized_name":"strength"},{"widget":{"name":"low_mem_load"},"shape":7,"name":"low_mem_load","label":"low_mem_load","type":"BOOLEAN","localized_name":"low_mem_load"},{"widget":{"name":"merge_loras"},"shape":7,"name":"merge_loras","label":"merge_loras","type":"BOOLEAN","localized_name":"merge_loras"}],"flags":{},"id":33,"type":"WanVideoLoraSelect","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoLoraSelect"},"order":12},{"mode":0,"outputs":[{"name":"lora","links":[32],"label":"lora","type":"WANVIDLORA","localized_name":"lora"}],"size":[270,150],"pos":[851.8678588867188,1724.2310791015625],"widgets_values":["Wan2.2-Fun-A14B-InP-high-noise-MPS.safetensors",0.7894000000000001,false,false],"inputs":[{"shape":7,"name":"prev_lora","link":52,"label":"prev_lora","type":"WANVIDLORA","localized_name":"prev_lora"},{"shape":7,"name":"blocks","label":"blocks","type":"SELECTEDBLOCKS","localized_name":"blocks"},{"widget":{"name":"lora"},"name":"lora","label":"lora","type":"COMBO","localized_name":"lora"},{"widget":{"name":"strength"},"name":"strength","label":"strength","type":"FLOAT","localized_name":"strength"},{"widget":{"name":"low_mem_load"},"shape":7,"name":"low_mem_load","label":"low_mem_load","type":"BOOLEAN","localized_name":"low_mem_load"},{"widget":{"name":"merge_loras"},"shape":7,"name":"merge_loras","label":"merge_loras","type":"BOOLEAN","localized_name":"merge_loras"}],"flags":{},"id":34,"type":"WanVideoLoraSelect","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoLoraSelect"},"order":27},{"mode":0,"outputs":[{"name":"FLOAT","links":[35,38],"label":"浮点","type":"FLOAT","localized_name":"浮点"}],"size":[270,58],"pos":[3345.28466796875,3244.904541015625],"widgets_values":[8.000000000000002],"inputs":[{"widget":{"name":"value"},"name":"value","label":"value","type":"FLOAT","localized_name":"value"}],"flags":{},"id":35,"type":"Float","properties":{"widget_ue_connectable":{},"Node name for S&R":"Float"},"order":13},{"mode":0,"outputs":[{"name":"float_list","links":[46],"label":"float_list","type":"FLOAT","localized_name":"float_list"}],"size":[298.3199157714844,178],"pos":[3512.231201171875,2413.898193359375],"widgets_values":[30,2,2,"linear",0,0.01],"inputs":[{"widget":{"name":"steps"},"name":"steps","link":53,"label":"steps","type":"INT","localized_name":"steps"},{"widget":{"name":"cfg_scale_start"},"name":"cfg_scale_start","label":"cfg_scale_start","type":"FLOAT","localized_name":"cfg_scale_start"},{"widget":{"name":"cfg_scale_end"},"name":"cfg_scale_end","label":"cfg_scale_end","type":"FLOAT","localized_name":"cfg_scale_end"},{"widget":{"name":"interpolation"},"name":"interpolation","label":"interpolation","type":"COMBO","localized_name":"interpolation"},{"widget":{"name":"start_percent"},"name":"start_percent","label":"start_percent","type":"FLOAT","localized_name":"start_percent"},{"widget":{"name":"end_percent"},"name":"end_percent","label":"end_percent","type":"FLOAT","localized_name":"end_percent"}],"flags":{},"id":36,"type":"CreateCFGScheduleFloatList","properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"7e290c67bff1f906cdab84523018573f6c9d4d7f","widget_ue_connectable":{"steps":true},"Node name for S&R":"CreateCFGScheduleFloatList"},"order":24},{"mode":4,"outputs":[{"name":"FLOAT","links":[33],"label":"FLOAT","type":"FLOAT","localized_name":"浮点"}],"size":[400,200],"pos":[836.4411010742188,1951.4901123046875],"widgets_values":["0,0,3,3"],"inputs":[{"widget":{"name":"string"},"name":"string","label":"string","type":"STRING","localized_name":"string"}],"flags":{},"id":37,"type":"StringToFloatList","properties":{"widget_ue_connectable":{},"Node name for S&R":"StringToFloatList"},"order":14},{"mode":0,"outputs":[{"widget":{"name":"seed"},"name":"INT","links":[23,48],"label":"INT","type":"INT"}],"size":[210,82],"pos":[1300.8525390625,2413.846923828125],"widgets_values":[317786370021218,"fixed"],"inputs":[],"flags":{},"id":38,"type":"PrimitiveNode","properties":{"widget_ue_connectable":{},"Run widget replace on values":false},"order":15},{"mode":0,"outputs":[{"name":"Filenames","label":"文件名","type":"VHS_FILENAMES","localized_name":"Filenames"}],"size":[698.6392211914062,1276.852294921875],"pos":[5130.2841796875,1854.2337646484375],"widgets_values":{"save_output":true,"filename_prefix":"WanVideo2_2_I2V","loop_count":0,"pix_fmt":"yuv420p","save_metadata":true,"crf":19,"trim_to_audio":false,"videopreview":{"paused":false,"hidden":false,"params":{"filename":"WanVideo2_2_I2V_00001_p82_vmkez_1757915768.mp4","workflow":"WanVideo2_2_I2V_00001_p82.png","fullpath":"/data/ComfyUI/personal/0c5e29f80acd84973c41e3a9c4cab22f/output/WanVideo2_2_I2V_00001_p82.mp4","format":"video/h264-mp4","subfolder":"","type":"output","frame_rate":16}},"format":"video/h264-mp4","no_preview":false,"frame_rate":16,"pingpong":false},"inputs":[{"name":"images","link":54,"label":"图像","type":"IMAGE","localized_name":"images"},{"shape":7,"name":"audio","label":"音频","type":"AUDIO","localized_name":"audio"},{"shape":7,"name":"meta_batch","label":"批次管理","type":"VHS_BatchManager","localized_name":"meta_batch"},{"shape":7,"name":"vae","label":"vae","type":"VAE","localized_name":"vae"},{"widget":{"name":"frame_rate"},"name":"frame_rate","label":"frame_rate","type":"FLOAT","localized_name":"帧率"},{"widget":{"name":"loop_count"},"name":"loop_count","label":"loop_count","type":"INT","localized_name":"循环次数"},{"widget":{"name":"filename_prefix"},"name":"filename_prefix","label":"filename_prefix","type":"STRING","localized_name":"文件名前缀"},{"widget":{"name":"format"},"name":"format","label":"format","type":"COMBO","localized_name":"格式"},{"widget":{"name":"pingpong"},"name":"pingpong","label":"pingpong","type":"BOOLEAN","localized_name":"Ping-Pong"},{"widget":{"name":"save_output"},"name":"save_output","label":"save_output","type":"BOOLEAN","localized_name":"保存到输出文件夹"},{"widget":{"name":"no_preview"},"shape":7,"name":"no_preview","label":"no_preview","type":"BOOLEAN","localized_name":"no_preview"}],"flags":{},"id":39,"type":"VHS_VideoCombine","properties":{"cnr_id":"comfyui-videohelpersuite","ver":"0a75c7958fe320efcb052f1d9f8451fd20c730a8","widget_ue_connectable":{},"Node name for S&R":"VHS_VideoCombine"},"order":57},{"outputs":[{"name":"images","slot_index":0,"links":[9,57],"label":"images","type":"IMAGE","localized_name":"images"}],"color":"#322","widgets_values":[false,272,272,144,128,"default"],"inputs":[{"name":"vae","link":55,"label":"vae","type":"WANVAE","localized_name":"vae"},{"name":"samples","link":56,"label":"samples","type":"LATENT","localized_name":"samples"},{"widget":{"name":"enable_vae_tiling"},"name":"enable_vae_tiling","label":"enable_vae_tiling","type":"BOOLEAN","localized_name":"enable_vae_tiling"},{"widget":{"name":"tile_x"},"name":"tile_x","label":"tile_x","type":"INT","localized_name":"tile_x"},{"widget":{"name":"tile_y"},"name":"tile_y","label":"tile_y","type":"INT","localized_name":"tile_y"},{"widget":{"name":"tile_stride_x"},"name":"tile_stride_x","label":"tile_stride_x","type":"INT","localized_name":"tile_stride_x"},{"widget":{"name":"tile_stride_y"},"name":"tile_stride_y","label":"tile_stride_y","type":"INT","localized_name":"tile_stride_y"},{"widget":{"name":"normalization"},"shape":7,"name":"normalization","label":"normalization","type":"COMBO","localized_name":"normalization"}],"flags":{},"type":"WanVideoDecode","mode":0,"bgcolor":"#533","size":[315,198],"pos":[4686.93212890625,1796.2735595703125],"id":40,"properties":{"cnr_id":"ComfyUI-WanVideoWrapper","ver":"998a69cc0acbec503001b8b0ce0a5d5404420e1e","widget_ue_connectable":{},"Node name for S&R":"WanVideoDecode"},"order":54},{"mode":0,"outputs":[{"name":"IMAGE","links":[58],"label":"IMAGE","type":"IMAGE","localized_name":"图像"}],"size":[400,200],"pos":[5130.1123046875,1555.9732666015625],"widgets_values":[16,95,""],"inputs":[{"name":"images","link":57,"label":"images","type":"IMAGE","localized_name":"images"},{"widget":{"name":"fps"},"name":"fps","label":"fps","type":"FLOAT","localized_name":"fps"},{"widget":{"name":"quality"},"name":"quality","label":"quality","type":"INT","localized_name":"quality"},{"widget":{"name":"usage_notes"},"shape":7,"name":"usage_notes","label":"usage_notes","type":"STRING","localized_name":"usage_notes"}],"flags":{},"id":41,"type":"TT_img_enc","properties":{"widget_ue_connectable":{},"Node name for S&R":"TT_img_enc"},"order":56},{"mode":0,"outputs":[],"size":[270,270],"pos":[5603.4248046875,1465.8404541015625],"widgets_values":["ComfyUI"],"inputs":[{"name":"images","link":58,"label":"图像","type":"IMAGE","localized_name":"图片"},{"widget":{"name":"filename_prefix"},"name":"filename_prefix","type":"STRING","localized_name":"文件名前缀"}],"flags":{},"id":42,"type":"SaveImage","properties":{"widget_ue_connectable":{},"Node name for S&R":"SaveImage"},"order":58},{"mode":0,"outputs":[{"name":"CONDITIONING","links":[76],"label":"条件","type":"CONDITIONING","localized_name":"条件"}],"bgcolor":"#593930","size":[240,26],"color":"#332922","pos":[-890.110595703125,1850.38525390625],"inputs":[{"name":"conditioning","link":59,"label":"条件","type":"CONDITIONING","localized_name":"条件"}],"flags":{"collapsed":false},"id":43,"type":"ConditioningZeroOut","properties":{"cnr_id":"comfy-core","ver":"0.3.39","widget_ue_connectable":{},"Node name for S&R":"ConditioningZeroOut"},"order":37},{"mode":0,"outputs":[{"name":"IMAGE","links":[65,68],"label":"IMAGE","type":"IMAGE","localized_name":"图像"}],"bgcolor":"#593930","size":[270,30],"color":"#332922","pos":[-1190.110595703125,2220.38525390625],"inputs":[{"name":"image","link":60,"label":"image","type":"IMAGE","localized_name":"image"}],"flags":{"collapsed":false},"id":44,"type":"FluxKontextImageScale","properties":{"cnr_id":"comfy-core","ver":"0.3.38","widget_ue_connectable":{},"Node name for S&R":"FluxKontextImageScale"},"order":39},{"outputs":[{"name":"IMAGE","links":[60],"label":"IMAGE","type":"IMAGE","localized_name":"图像"}],"color":"#332922","widgets_values":["right",true,0,"white"],"inputs":[{"name":"image1","link":61,"label":"image1","type":"IMAGE","localized_name":"image1"},{"shape":7,"name":"image2","label":"image2","type":"IMAGE","localized_name":"image2"},{"widget":{"name":"direction"},"name":"direction","label":"direction","type":"COMBO","localized_name":"direction"},{"widget":{"name":"match_image_size"},"name":"match_image_size","label":"match_image_size","type":"BOOLEAN","localized_name":"match_image_size"},{"widget":{"name":"spacing_width"},"name":"spacing_width","label":"spacing_width","type":"INT","localized_name":"spacing_width"},{"widget":{"name":"spacing_color"},"name":"spacing_color","label":"spacing_color","type":"COMBO","localized_name":"spacing_color"}],"flags":{},"type":"ImageStitch","mode":0,"bgcolor":"#593930","size":[270,150],"pos":[-1530.110595703125,2220.38525390625],"id":45,"properties":{"cnr_id":"comfy-core","ver":"0.3.40","widget_ue_connectable":{},"Node name for S&R":"ImageStitch"},"order":32},{"outputs":[{"name":"CONDITIONING","slot_index":0,"links":[75],"label":"条件","type":"CONDITIONING","localized_name":"条件"}],"color":"#332922","widgets_values":[2.5],"inputs":[{"name":"conditioning","link":62,"label":"条件","type":"CONDITIONING","localized_name":"条件"},{"widget":{"name":"guidance"},"name":"guidance","type":"FLOAT","localized_name":"引导"}],"flags":{"collapsed":false},"type":"FluxGuidance","mode":0,"bgcolor":"#593930","size":[240,58],"pos":[-890.110595703125,1740.38525390625],"id":46,"properties":{"cnr_id":"comfy-core","ver":"0.3.38","widget_ue_connectable":{},"Node name for S&R":"FluxGuidance"},"order":45},{"mode":0,"outputs":[{"name":"CONDITIONING","links":[62],"label":"CONDITIONING","type":"CONDITIONING","localized_name":"条件"}],"bgcolor":"#593930","size":[197.712890625,46],"color":"#332922","pos":[-1130.110595703125,1790.38525390625],"inputs":[{"name":"conditioning","link":63,"label":"conditioning","type":"CONDITIONING","localized_name":"conditioning"},{"shape":7,"name":"latent","link":64,"label":"latent","type":"LATENT","localized_name":"latent"}],"flags":{},"id":47,"type":"ReferenceLatent","properties":{"cnr_id":"comfy-core","ver":"0.3.41","widget_ue_connectable":{},"Node name for S&R":"ReferenceLatent"},"order":44},{"outputs":[{"name":"VAE","links":[66,73],"type":"VAE","localized_name":"VAE"}],"color":"#332922","widgets_values":["ae.safetensors"],"inputs":[{"widget":{"name":"vae_name"},"name":"vae_name","type":"COMBO","localized_name":"vae名称"}],"flags":{},"type":"VAELoader","mode":0,"bgcolor":"#593930","size":[337.76861572265625,58],"pos":[-1540.110595703125,2040.38525390625],"id":48,"properties":{"cnr_id":"comfy-core","models":[{"name":"ae.safetensors","directory":"vae","url":"https://huggingface.co/Comfy-Org/Lumina_Image_2.0_Repackaged/resolve/main/split_files/vae/ae.safetensors"}],"ver":"0.3.38","widget_ue_connectable":{},"Node name for S&R":"VAELoader"},"order":16},{"mode":0,"outputs":[{"name":"LATENT","links":[64,77],"label":"Latent","type":"LATENT","localized_name":"Latent"}],"bgcolor":"#593930","size":[240,50],"color":"#332922","pos":[-1133.08447265625,2015.8519287109375],"inputs":[{"name":"pixels","link":65,"label":"图像","type":"IMAGE","localized_name":"像素"},{"name":"vae","link":66,"label":"VAE","type":"VAE","localized_name":"vae"}],"flags":{"collapsed":false},"id":49,"type":"VAEEncode","properties":{"cnr_id":"comfy-core","ver":"0.3.39","widget_ue_connectable":{},"Node name for S&R":"VAEEncode"},"order":42},{"outputs":[{"name":"CLIP","links":[69],"label":"CLIP","type":"CLIP","localized_name":"CLIP"}],"color":"#332922","widgets_values":["clip_l.safetensors","t5xxl_fp8_e4m3fn.safetensors","flux","default"],"inputs":[{"widget":{"name":"clip_name1"},"name":"clip_name1","type":"COMBO","localized_name":"CLIP1"},{"widget":{"name":"clip_name2"},"name":"clip_name2","type":"COMBO","localized_name":"CLIP2"},{"widget":{"name":"type"},"name":"type","type":"COMBO","localized_name":"类型"},{"widget":{"name":"device"},"shape":7,"name":"device","type":"COMBO","localized_name":"设备"}],"flags":{},"type":"DualCLIPLoader","mode":0,"bgcolor":"#593930","size":[337.76861572265625,130],"pos":[-1540.110595703125,1860.38525390625],"id":50,"properties":{"cnr_id":"comfy-core","models":[{"name":"clip_l.safetensors","directory":"text_encoders","url":"https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors"},{"name":"t5xxl_fp8_e4m3fn_scaled.safetensors","directory":"text_encoders","url":"https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp8_e4m3fn_scaled.safetensors"}],"ver":"0.3.38","widget_ue_connectable":{},"Node name for S&R":"DualCLIPLoader"},"order":17},{"outputs":[{"name":"CONDITIONING","slot_index":0,"links":[59,63],"label":"条件","type":"CONDITIONING","localized_name":"条件"}],"color":"#332922","widgets_values":["make the woman's breasts larger "],"inputs":[{"name":"clip","link":69,"label":"CLIP","type":"CLIP","localized_name":"clip"},{"widget":{"name":"text"},"name":"text","type":"STRING","localized_name":"文本"}],"flags":{},"type":"CLIPTextEncode","mode":0,"bgcolor":"#593930","size":[400,220],"pos":[-816.547607421875,2182.706298828125],"id":53,"properties":{"cnr_id":"comfy-core","ver":"0.3.38","widget_ue_connectable":{},"Node name for S&R":"CLIPTextEncode"},"order":30},{"outputs":[{"name":"MODEL","links":[71],"label":"模型","type":"MODEL","localized_name":"模型"}],"color":"#332922","widgets_values":["kontext_big_breasts_and_butts.safetensors",1.0000000000000002],"inputs":[{"name":"model","link":70,"label":"模型","type":"MODEL","localized_name":"模型"},{"widget":{"name":"lora_name"},"name":"lora_name","type":"COMBO","localized_name":"LoRA名称"},{"widget":{"name":"strength_model"},"name":"strength_model","type":"FLOAT","localized_name":"模型强度"}],"flags":{},"type":"LoraLoaderModelOnly","mode":0,"bgcolor":"#593930","size":[358.5085754394531,129.4727783203125],"pos":[-1481.145751953125,1448.383056640625],"id":54,"properties":{"cnr_id":"comfy-core","ver":"0.3.43","widget_ue_connectable":{},"Node name for S&R":"LoraLoaderModelOnly","ttNbgOverride":{"bgcolor":"#593930","groupcolor":"#b06634","color":"#332922"}},"order":31},{"outputs":[{"name":"model","links":[74],"label":"model","type":"MODEL","localized_name":"model"}],"color":"#332922","widgets_values":["flux",0.22000000000000003,0.20000000000000004,0.9000000000000001,"cuda"],"inputs":[{"name":"model","link":71,"label":"model","type":"MODEL","localized_name":"model"},{"widget":{"name":"model_type"},"name":"model_type","label":"model_type","type":"COMBO","localized_name":"model_type"},{"widget":{"name":"rel_l1_thresh"},"name":"rel_l1_thresh","label":"rel_l1_thresh","type":"FLOAT","localized_name":"rel_l1_thresh"},{"widget":{"name":"start_percent"},"name":"start_percent","label":"start_percent","type":"FLOAT","localized_name":"start_percent"},{"widget":{"name":"end_percent"},"name":"end_percent","label":"end_percent","type":"FLOAT","localized_name":"end_percent"},{"widget":{"name":"cache_device"},"name":"cache_device","label":"cache_device","type":"COMBO","localized_name":"cache_device"}],"flags":{},"type":"TeaCache","mode":0,"bgcolor":"#593930","size":[315,154],"pos":[-923.6541137695312,1382.9505615234375],"id":55,"properties":{"widget_ue_connectable":{},"Node name for S&R":"TeaCache","ttNbgOverride":{"bgcolor":"#593930","groupcolor":"#b06634","color":"#332922"}},"order":38},{"outputs":[{"name":"MODEL","links":[70],"label":"MODEL","type":"MODEL","localized_name":"模型"}],"color":"#332922","widgets_values":["flux1-kontext-dev-Q8_0.gguf"],"inputs":[{"widget":{"name":"unet_name"},"name":"unet_name","label":"unet_name","type":"COMBO","localized_name":"unet_name"}],"flags":{},"type":"UnetLoaderGGUF","mode":0,"bgcolor":"#593930","size":[315,58],"pos":[-1968.0472412109375,1362.6566162109375],"id":56,"properties":{"widget_ue_connectable":{},"Node name for S&R":"UnetLoaderGGUF","ttNbgOverride":{"bgcolor":"#593930","groupcolor":"#b06634","color":"#332922"}},"order":18},{"outputs":[{"name":"IMAGE","slot_index":0,"links":[61],"label":"图像","type":"IMAGE","localized_name":"图像"},{"name":"MASK","slot_index":1,"label":"遮罩","type":"MASK","localized_name":"遮罩"}],"color":"#332922","widgets_values":["85e946abc49b9ada980925417be66768cb156e5b029330db0215c1381e54faaf.png","image"],"inputs":[{"widget":{"name":"image"},"name":"image","label":"image","type":"COMBO","localized_name":"图像"},{"widget":{"name":"upload"},"name":"upload","label":"upload","type":"IMAGEUPLOAD","localized_name":"选择文件上传"}],"flags":{},"type":"LoadImage","mode":0,"bgcolor":"#593930","size":[292.64263916015625,407.7149963378906],"pos":[-2113.510498046875,1903.5284423828125],"id":57,"properties":{"cnr_id":"comfy-core","ver":"0.3.52","widget_ue_connectable":{},"Node name for S&R":"LoadImage"},"order":19},{"outputs":[{"name":"LATENT","slot_index":0,"links":[72],"label":"Latent","type":"LATENT","localized_name":"Latent"}],"color":"#332922","widgets_values":[57956236525329,"randomize",8,1,"euler","simple",1],"inputs":[{"name":"model","link":74,"label":"模型","type":"MODEL","localized_name":"模型"},{"name":"positive","link":75,"label":"正面条件","type":"CONDITIONING","localized_name":"正面条件"},{"name":"negative","link":76,"label":"负面条件","type":"CONDITIONING","localized_name":"负面条件"},{"name":"latent_image","link":77,"label":"Latent","type":"LATENT","localized_name":"Latent图像"},{"widget":{"name":"seed"},"name":"seed","type":"INT","localized_name":"随机种"},{"widget":{"name":"steps"},"name":"steps","type":"INT","localized_name":"步数"},{"widget":{"name":"cfg"},"name":"cfg","type":"FLOAT","localized_name":"CFG"},{"widget":{"name":"sampler_name"},"name":"sampler_name","type":"COMBO","localized_name":"采样器"},{"widget":{"name":"scheduler"},"name":"scheduler","type":"COMBO","localized_name":"调度器"},{"widget":{"name":"denoise"},"name":"denoise","type":"FLOAT","localized_name":"降噪"}],"flags":{},"type":"KSampler","mode":0,"bgcolor":"#593930","size":[320,262],"pos":[-514.1531372070312,1668.109375],"id":59,"properties":{"cnr_id":"comfy-core","ver":"0.3.38","widget_ue_connectable":{},"Node name for S&R":"KSampler"},"order":46},{"mode":0,"outputs":[{"name":"IMAGE","slot_index":0,"links":[67,79],"label":"图像","type":"IMAGE","localized_name":"图像"}],"bgcolor":"#593930","size":[190,46],"color":"#332922","pos":[-603.5845947265625,2037.676513671875],"inputs":[{"name":"samples","link":72,"label":"Latent","type":"LATENT","localized_name":"Latent"},{"name":"vae","link":73,"label":"VAE","type":"VAE","localized_name":"vae"}],"flags":{"collapsed":false},"id":58,"type":"VAEDecode","properties":{"cnr_id":"comfy-core","ver":"0.3.38","widget_ue_connectable":{},"Node name for S&R":"VAEDecode"},"order":47},{"mode":0,"outputs":[{"name":"any","links":[80],"label":"any","type":"*","localized_name":"any"}],"size":[279.6304626464844,82],"color":"rgba(38, 73, 116, 0.7)","pos":[201.6812744140625,1624.9404296875],"widgets_values":[true,true],"inputs":[{"name":"anything","link":79,"label":"anything","type":"*","localized_name":"anything"},{"widget":{"name":"purge_cache"},"name":"purge_cache","label":"purge_cache","type":"BOOLEAN","localized_name":"purge_cache"},{"widget":{"name":"purge_models"},"name":"purge_models","label":"purge_models","type":"BOOLEAN","localized_name":"purge_models"}],"flags":{},"id":60,"type":"LayerUtility: PurgeVRAM V2","properties":{"widget_ue_connectable":{},"Node name for S&R":"LayerUtility: PurgeVRAM V2"},"order":49},{"outputs":[],"color":"#332922","widgets_values":[],"inputs":[{"name":"images","link":67,"label":"图像","type":"IMAGE","localized_name":"图像"}],"flags":{},"type":"PreviewImage","mode":0,"bgcolor":"#593930","size":[140,246],"pos":[-61.00274658203125,1476.792236328125],"id":51,"properties":{"widget_ue_connectable":{},"Node name for S&R":"PreviewImage"},"order":48},{"mode":0,"outputs":[{"name":"context_options","links":[44],"label":"context_options","type":"WANVIDCONTEXT","localized_name":"context_options"}],"size":[275.783203125,202],"pos":[3494.78369140625,2151.859130859375],"widgets_values":["uniform_standard",81,4,16,true,false,"linear"],"inputs":[{"shape":7,"name":"reference_latent","label":"reference_latent","type":"LATENT","localized_name":"reference_latent"},{"widget":{"name":"context_schedule"},"name":"context_schedule","label":"context_schedule","type":"COMBO","localized_name":"context_schedule"},{"widget":{"name":"context_frames"},"name":"context_frames","label":"context_frames","type":"INT","localized_name":"context_frames"},{"widget":{"name":"context_stride"},"name":"context_stride","label":"context_stride","type":"INT","localized_name":"context_stride"},{"widget":{"name":"context_overlap"},"name":"context_overlap","label":"context_overlap","type":"INT","localized_name":"context_overlap"},{"widget":{"name":"freenoise"},"name":"freenoise","label":"freenoise","type":"BOOLEAN","localized_name":"freenoise"},{"widget":{"name":"verbose"},"name":"verbose","label":"verbose","type":"BOOLEAN","localized_name":"verbose"},{"widget":{"name":"fuse_method"},"shape":7,"name":"fuse_method","label":"fuse_method","type":"COMBO","localized_name":"fuse_method"}],"flags":{},"id":29,"type":"WanVideoContextOptions","properties":{"widget_ue_connectable":{},"Node name for S&R":"WanVideoContextOptions"},"order":20},{"outputs":[],"color":"#332922","widgets_values":[],"inputs":[{"name":"images","link":68,"label":"图像","type":"IMAGE","localized_name":"图像"}],"flags":{},"type":"PreviewImage","mode":0,"bgcolor":"#593930","size":[420,310],"pos":[-799.3062133789062,2451.93994140625],"id":52,"properties":{"cnr_id":"comfy-core","ver":"0.3.40","widget_ue_connectable":{},"Node name for S&R":"PreviewImage"},"order":43},{"mode":0,"outputs":[{"name":"INT","links":[16],"label":"INT","type":"INT","localized_name":"整数"}],"size":[270,58],"pos":[964.264892578125,2564.062744140625],"widgets_values":[199],"inputs":[{"widget":{"name":"value"},"name":"value","label":"value","type":"INT","localized_name":"value"}],"flags":{},"id":32,"type":"JWInteger","properties":{"widget_ue_connectable":{},"Node name for S&R":"JWInteger"},"order":21}],"extra":{"links_added_by_ue":[],"ue_links":[],"0246.VERSION":[0,0,4],"ds":{"offset":[-678.5171040703981,-1044.7847168270496],"scale":0.5131581182307067}},"groups":[{"color":"#3f789e","font_size":240,"flags":{},"id":1,"title":"B站、Youtube：T8star-Aix","bounding":[1312.4202880859375,648.1737060546875,4168,309]}],"links":[[1,13,0,2,0,"WANVIDEOMODEL"],[2,17,0,2,1,"BLOCKSWAPARGS"],[3,14,0,3,0,"WANVIDEOMODEL"],[4,17,0,3,1,"BLOCKSWAPARGS"],[5,3,0,4,0,"WANVIDEOMODEL"],[6,15,0,4,1,"WANVIDLORA"],[7,2,0,5,0,"WANVIDEOMODEL"],[8,20,0,5,1,"WANVIDLORA"],[9,40,0,6,0,"IMAGE"],[11,31,0,7,9,"INT"],[12,8,0,9,0,"WANVAE"],[13,7,0,9,2,"IMAGE"],[14,7,3,9,8,"INT"],[15,7,4,9,9,"INT"],[16,32,0,9,10,"INT"],[17,4,0,11,0,"WANVIDEOMODEL"],[18,16,0,11,1,"WANVIDEOTEXTEMBEDS"],[19,9,0,11,2,"WANVIDIMAGE_EMBEDS"],[20,28,0,11,3,"LATENT"],[21,21,1,11,17,"INT"],[22,21,2,11,19,"FLOAT"],[23,38,0,11,20,"INT"],[24,21,3,11,22,"COMBO"],[25,21,4,11,27,"INT"],[26,21,5,11,28,"INT"],[27,18,0,13,0,"WANCOMPILEARGS"],[28,18,0,14,0,"WANCOMPILEARGS"],[29,25,0,15,0,"WANVIDLORA"],[30,10,0,16,0,"WANTEXTENCODER"],[31,27,0,16,2,"STRING"],[32,34,0,20,0,"WANVIDLORA"],[33,37,0,20,3,"FLOAT"],[34,19,0,21,2,"INT"],[35,35,0,21,3,"FLOAT"],[36,23,0,21,4,"INT"],[37,19,0,22,2,"INT"],[38,35,0,22,3,"FLOAT"],[39,23,0,22,5,"INT"],[40,26,0,25,0,"WANVIDLORA"],[41,5,0,28,0,"WANVIDEOMODEL"],[42,16,0,28,1,"WANVIDEOTEXTEMBEDS"],[43,9,0,28,2,"WANVIDIMAGE_EMBEDS"],[44,29,0,28,5,"WANVIDCONTEXT"],[45,22,1,28,17,"INT"],[46,36,0,28,18,"FLOAT"],[47,22,2,28,19,"FLOAT"],[48,38,0,28,20,"INT"],[49,22,3,28,22,"COMBO"],[50,22,4,28,27,"INT"],[51,22,5,28,28,"INT"],[52,33,0,34,0,"WANVIDLORA"],[53,19,0,36,0,"INT"],[54,6,0,39,0,"IMAGE"],[55,8,0,40,0,"WANVAE"],[56,11,0,40,1,"LATENT"],[57,40,0,41,0,"IMAGE"],[58,41,0,42,0,"IMAGE"],[59,53,0,43,0,"CONDITIONING"],[60,45,0,44,0,"IMAGE"],[61,57,0,45,0,"IMAGE"],[62,47,0,46,0,"CONDITIONING"],[63,53,0,47,0,"CONDITIONING"],[64,49,0,47,1,"LATENT"],[65,44,0,49,0,"IMAGE"],[66,48,0,49,1,"VAE"],[67,58,0,51,0,"IMAGE"],[68,44,0,52,0,"IMAGE"],[69,50,0,53,0,"CLIP"],[70,56,0,54,0,"MODEL"],[71,54,0,55,0,"MODEL"],[72,59,0,58,0,"LATENT"],[73,48,0,58,1,"VAE"],[74,55,0,59,0,"MODEL"],[75,46,0,59,1,"CONDITIONING"],[76,43,0,59,2,"CONDITIONING"],[77,49,0,59,3,"LATENT"],[79,58,0,60,0,"*"],[80,60,0,7,0,"IMAGE"]],"id":"c021c570-4ec8-4417-80c3-692386fe410e","config":{},"version":0.4,"last_node_id":60,"revision":0}
+{
+  "id": "c021c570-4ec8-4417-80c3-692386fe410e",
+  "revision": 0,
+  "last_node_id": 60,
+  "last_link_id": 126,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        413,
+        389
+      ],
+      "size": [
+        425.27801513671875,
+        180.6060791015625
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            98
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 54,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        486.4836120605469,
+        -69.28914642333984
+      ],
+      "size": [
+        315,
+        58
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 110
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            125
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingSD3"
+      },
+      "widgets_values": [
+        8.000000000000002
+      ]
+    },
+    {
+      "id": 55,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        484.0019836425781,
+        54.46213912963867
+      ],
+      "size": [
+        315,
+        58
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 112
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            123
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingSD3"
+      },
+      "widgets_values": [
+        8
+      ]
+    },
+    {
+      "id": 58,
+      "type": "KSamplerAdvanced",
+      "pos": [
+        1262.509765625,
+        -26.73247528076172
+      ],
+      "size": [
+        304.748046875,
+        334
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 123
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 121
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 122
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 113
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            124
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSamplerAdvanced"
+      },
+      "widgets_values": [
+        "disable",
+        0,
+        "fixed",
+        20,
+        3.5,
+        "euler",
+        "simple",
+        10,
+        10000,
+        "disable"
+      ]
+    },
+    {
+      "id": 38,
+      "type": "CLIPLoader",
+      "pos": [
+        30,
+        190
+      ],
+      "size": [
+        360,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            74,
+            75
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        30,
+        -70
+      ],
+      "size": [
+        430,
+        82
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            110
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 56,
+      "type": "UNETLoader",
+      "pos": [
+        30,
+        60
+      ],
+      "size": [
+        430,
+        82
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            112
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        30,
+        340
+      ],
+      "size": [
+        360,
+        58
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            76,
+            99
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "wan_2.1_vae.safetensors"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 59,
+      "type": "Note",
+      "pos": [
+        -202.05557250976562,
+        -57.859466552734375
+      ],
+      "size": [
+        210,
+        159.49227905273438
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "This model uses a different diffusion model for the first steps (high noise) vs the last steps (low noise).\n\n"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 60,
+      "type": "Note",
+      "pos": [
+        -200,
+        340
+      ],
+      "size": [
+        210,
+        159.49227905273438
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "This model uses the wan 2.1 VAE.\n\n\n"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1590,
+        -20
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 124
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            56,
+            93
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 47,
+      "type": "SaveWEBM",
+      "pos": [
+        2530,
+        -20
+      ],
+      "size": [
+        763.67041015625,
+        885.67041015625
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 93
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveWEBM"
+      },
+      "widgets_values": [
+        "full_firm_bouncy_breasts",
+        "vp9",
+        16.000000000000004,
+        13.3333740234375
+      ]
+    },
+    {
+      "id": 57,
+      "type": "KSamplerAdvanced",
+      "pos": [
+        893.0060424804688,
+        -29.923471450805664
+      ],
+      "size": [
+        304.748046875,
+        334
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 125
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 118
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 119
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 120
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            113
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSamplerAdvanced"
+      },
+      "widgets_values": [
+        "enable",
+        317786370021218,
+        "fixed",
+        20,
+        3.5,
+        "euler",
+        "simple",
+        0,
+        10,
+        "enable"
+      ]
+    },
+    {
+      "id": 28,
+      "type": "SaveAnimatedWEBP",
+      "pos": [
+        1820,
+        -20
+      ],
+      "size": [
+        674.6224975585938,
+        820.6224975585938
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 56
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "full_firm_bouncy_breasts",
+        16,
+        false,
+        80,
+        "default"
+      ]
+    },
+    {
+      "id": 50,
+      "type": "WanImageToVideo",
+      "pos": [
+        491.7362060546875,
+        617.798095703125
+      ],
+      "size": [
+        342.5999755859375,
+        210
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 97
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 98
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 99
+        },
+        {
+          "name": "clip_vision_output",
+          "shape": 7,
+          "type": "CLIP_VISION_OUTPUT",
+          "link": null
+        },
+        {
+          "name": "start_image",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 126
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            118,
+            121
+          ]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "slot_index": 1,
+          "links": [
+            119,
+            122
+          ]
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "slot_index": 2,
+          "links": [
+            120
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "WanImageToVideo"
+      },
+      "widgets_values": [
+        768,
+        768,
+        81,
+        1
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        415,
+        186
+      ],
+      "size": [
+        422.84503173828125,
+        164.31304931640625
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            97
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "女人拿着相机拍照, her breasts bounce, shake, jiggle and sway"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 52,
+      "type": "LoadImage",
+      "pos": [
+        -50,
+        550
+      ],
+      "size": [
+        450,
+        540
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            126
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "85e946abc49b9ada980925417be66768cb156e5b029330db0215c1381e54faaf.png",
+        "image"
+      ]
+    }
+  ],
+  "links": [
+    [
+      56,
+      8,
+      0,
+      28,
+      0,
+      "IMAGE"
+    ],
+    [
+      74,
+      38,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      75,
+      38,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      76,
+      39,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      93,
+      8,
+      0,
+      47,
+      0,
+      "IMAGE"
+    ],
+    [
+      97,
+      6,
+      0,
+      50,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      98,
+      7,
+      0,
+      50,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      99,
+      39,
+      0,
+      50,
+      2,
+      "VAE"
+    ],
+    [
+      110,
+      37,
+      0,
+      54,
+      0,
+      "MODEL"
+    ],
+    [
+      112,
+      56,
+      0,
+      55,
+      0,
+      "MODEL"
+    ],
+    [
+      113,
+      57,
+      0,
+      58,
+      3,
+      "LATENT"
+    ],
+    [
+      118,
+      50,
+      0,
+      57,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      119,
+      50,
+      1,
+      57,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      120,
+      50,
+      2,
+      57,
+      3,
+      "LATENT"
+    ],
+    [
+      121,
+      50,
+      0,
+      58,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      122,
+      50,
+      1,
+      58,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      123,
+      55,
+      0,
+      58,
+      0,
+      "MODEL"
+    ],
+    [
+      124,
+      58,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      125,
+      54,
+      0,
+      57,
+      0,
+      "MODEL"
+    ],
+    [
+      126,
+      52,
+      0,
+      50,
+      4,
+      "IMAGE"
+    ]
+  ],
+  "groups": [
+    {
+      "color": "#3f789e",
+      "font_size": 240,
+      "flags": {},
+      "id": 1,
+      "title": "B站、Youtube：T8star-Aix",
+      "bounding": [
+        1312.4202880859375,
+        648.1737060546875,
+        4168,
+        309
+      ]
+    }
+  ],
+  "config": {},
+  "extra": {
+    "links_added_by_ue": [],
+    "ue_links": [],
+    "0246.VERSION": [
+      0,
+      0,
+      4
+    ],
+    "ds": {
+      "offset": [
+        -678.5171040703981,
+        -1044.7847168270496
+      ],
+      "scale": 0.5131581182307067
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary
- rebuild the bouncy breasts workflow around the WanImageToVideo pipeline that ships with the base extension
- reuse the original positive/negative prompt text and reference image inside supported CLIP and loader nodes
- retune sampler seed and output filenames so the template remains deterministic and self-contained

## Testing
- python -m json.tool 'workflow-full-firm-and-bouncy-breasts-wan22-vafG1WJ7DDiCFAO8IpbY-wwrs-openart.ai (1).json'


------
https://chatgpt.com/codex/tasks/task_e_68d4537db704832f9c73b3050646efec